### PR TITLE
Auth progress - frontend

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -15,9 +15,9 @@ var css = require("../client/public/css/styles.css")
 
 
 
-window.globalStateItemID = null;
-window.globalStateUserID = null;
-window.globalStateSessionID = null;
+window.globalStateItemID = window.globalStateItemID || null;
+window.globalStateUserID = window.globalStateUserID || null;
+window.globalStateSessionID = window.globalStateSessionID || null;
 
 
 

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -17,6 +17,7 @@ var css = require("../client/public/css/styles.css")
 
 window.globalStateItemID = null;
 window.globalStateUserID = null;
+window.globalStateSessionID = null;
 
 
 

--- a/client/components/Login.jsx
+++ b/client/components/Login.jsx
@@ -31,7 +31,10 @@ handlePasswordChange: function(e) {
   },
 
 logout: function(){
-	 postRequests.logout( {userID: window.globalStateUserID} )
+	 postRequests.logout( {
+	 	userID: window.globalStateUserID, 
+	 	cookie: {sessionId: window.globalStateSessionID}
+	 } )
 },
 
 submit: function(){

--- a/client/requests/post.js
+++ b/client/requests/post.js
@@ -88,6 +88,7 @@ exports.login = function(loginObject){
       console.log('login RESPONSE: ', response);
       console.log('login RESPONSE ID: ', response.user.userID);
       window.globalStateUserID = response.user.userID;
+      window.globalStateSessionID = response.sessionID;
       return response;
     })
 }
@@ -109,8 +110,9 @@ exports.logout = function(userID){
     })
 
 
-
-  return window.globalStateUserID = null;
+  window.globalStateUserID = null;
+  window.globalStateSessionID = null;
+  return;
 }
 
 

--- a/client/requests/post.js
+++ b/client/requests/post.js
@@ -20,6 +20,7 @@ exports.addNewItem = function(itemObject) {
   return fetch('items/', {
     method: 'POST',
     headers: requestHeaders,
+    credentials: 'include',
     body: JSON.stringify(itemObject)
   }).then(function(itemObject){
     return itemObject.json();
@@ -43,6 +44,7 @@ exports.searchForItem = function(itemName) {
   return fetch('items/search', {            
     method: 'POST',
     headers: requestHeaders,
+    credentials: 'include',
     body: JSON.stringify(itemName)
   }).then(function(response){
     return response.json()
@@ -96,6 +98,7 @@ exports.logout = function(userID){
   return fetch('logout/', {
     method: 'POST',
     headers: requestHeaders,
+    credentials: 'include',
     body: JSON.stringify(userID)
   }).then(function(userID){
     return userID.json();
@@ -122,6 +125,7 @@ exports.goToProfile = function(userID){
     return fetch('users/', {            //change this maybe
     method: 'POST',
     headers: requestHeaders,
+    credentials: 'include',
     body: JSON.stringify(userID)
   }).then( function(response) {
       console.log('USERID', response);
@@ -141,6 +145,7 @@ exports.getItem = function(itemID){
     return fetch('items/id', {
     method: 'POST',
     headers: requestHeaders,
+    credentials: 'include',
     body: JSON.stringify(itemID)
   }).then(function(itemID){
     return itemID.json();

--- a/client/requests/post.js
+++ b/client/requests/post.js
@@ -72,6 +72,8 @@ exports.signup = function(signupObject){
     return signupObject.json();
   }).then( function(response) {
       console.log('SIGNUP RESPONSE', response);
+      window.globalStateUserID = response.user.userID;
+      window.globalStateSessionID = response.sessionID;
       return response;
     })
 };

--- a/server.js
+++ b/server.js
@@ -55,9 +55,7 @@ routes.post('/login', function (req, res){
 
 routes.post('/logout', function (req, res){
   // log a user out.
-  console.log('HERE are the cookies (req.cookies): ', req.cookies)
   req.body.cookie = req.body.cookie || req.cookies;
-    console.log('req.body.cookie: ', req.body.cookie)
   helpers.logoutRoute(req.body)
     .then(function(response){
       res.status(200).send(response);

--- a/server.js
+++ b/server.js
@@ -45,7 +45,6 @@ routes.post('/login', function (req, res){
   helpers.loginRoute(req.body)
     .then(function(response){
       res.cookie('sessionId',response.sessionID, { maxAge: 604800000, httpOnly: true}) //valid for one week.
-      // console.log('RESRESRESRESRESRESRES', res.cookies)
         res.status(200).send(response);
     })
     .catch(function(err){

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ routes.post('/signup', function (req, res){
   // sign up a new user.
   helpers.signupRoute(req.body)
     .then(function(response){
-      res.cookie('sessionId',response.sessionID, { maxAge: 604800000, httpOnly: true }) //valid for one week.
+      res.cookie('sessionId',response.sessionID, { maxAge: 604800000, httpOnly: true}) //valid for one week.
         .status(200).send(response);
     })
     .catch(function(err){
@@ -44,8 +44,8 @@ routes.post('/login', function (req, res){
   // log a user in.
   helpers.loginRoute(req.body)
     .then(function(response){
-      res.cookie('sessionId',response.sessionID, { maxAge: 604800000, httpOnly: true }) //valid for one week.
-      console.log('RESRESRESRESRESRESRES', res)
+      res.cookie('sessionId',response.sessionID, { maxAge: 604800000, httpOnly: true}) //valid for one week.
+      // console.log('RESRESRESRESRESRESRES', res.cookies)
         res.status(200).send(response);
     })
     .catch(function(err){
@@ -55,7 +55,7 @@ routes.post('/login', function (req, res){
 
 routes.post('/logout', function (req, res){
   // log a user out.
-  console.log('req.cookies: ', req.cookies)
+  console.log('HERE are the cookies (req.cookies): ', req.cookies)
   req.body.cookie = req.body.cookie || req.cookies;
     console.log('req.body.cookie: ', req.body.cookie)
   helpers.logoutRoute(req.body)

--- a/serverHelpers.js
+++ b/serverHelpers.js
@@ -194,6 +194,7 @@ exports.logoutRoute = function(reqBody){
  			}
  			reject(body);
  		} else {
+ 			console.log('id inside logoutRoute: ', cookie.sessionId)
  			dbMethod.getSessionBySessionID(cookie.sessionId)
  				.then(function(res){
  					if(res === false){

--- a/serverHelpers.js
+++ b/serverHelpers.js
@@ -44,7 +44,8 @@ exports.signupRoute = function(reqBody){
  									sessionID = res[0];
  									var userObj = {
  										username : user.username,
- 										email : user.email
+ 										email : user.email,
+ 										userID: user.id
  									}
  									var body = {
  										'status' : 'completed',


### PR DESCRIPTION
cookies (+ sessionIds) are not adding to the browser. As a temp workaround: 
- sessionIds are now stored as global variables in app.jsx in a similar manner to userIds. 
- session ids are being passed to the server directly via the request body (instead of via cookies) to authenticate sign-outs.
- additionally, added a parameter to fetch() requests to allow them to send cookies from client to server. Prep for when we get cookies client-side.
